### PR TITLE
Handle temperatures of zero correctly

### DIFF
--- a/app/common.py
+++ b/app/common.py
@@ -41,5 +41,5 @@ def get_temperature(adc, cell_version):
     return round(fahrenheit, 2)
 
 def add_temperature(row):
-    if not row['temperature']:
+    if row['temperature'] == None and row['adc'] != None:
         row['temperature'] = get_temperature(row['adc'], row['version'])


### PR DESCRIPTION
We found a bug where readings of exactly 0ºF prevented the hubs pages from rendering. This should correct it by explicitly checking for None instead of falsiness.